### PR TITLE
rolled back some changes in a field template because it had wider-ran…

### DIFF
--- a/templates/paragraphs/fields/text/field--paragraph--field-txex-text-long-summary-01.html.twig
+++ b/templates/paragraphs/fields/text/field--paragraph--field-txex-text-long-summary-01.html.twig
@@ -7,3 +7,14 @@
 {% if field_modifiers %}
   {% set paragraph_modifiers = paragraph_modifiers|merge(field_modifiers) %}
 {% endif %}
+
+{% block item_block %}
+  {% if item.content %}
+    {% include "@atoms/03-text/02-paragraph/paragraph.twig" with {
+      "paragraph_blockname": field_blockname,
+      "paragraph_attributes": item.attributes,
+      "paragraph_modifiers": paragraph_modifiers,	
+      "paragraph_content": item.content|render|striptags,
+    } %}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
…ging implications than I thought

Reference: https://app.asana.com/XXX

**This PR does the following:**
- changes back the Drupal template for the body field being used in most paragraphs

### To Review:
- [ ] `cd web/themes/custom/d8-theme-main`
- [ ] `npm start`
- [ ] Navigate to the [Pattern](http://localhost:3000/pattern-lab/public/)
- [ ] Navigate to the [Drupal page](http://texasexesd8.lndo.site/)
