### PR TITLE
connected accordion styles to paragraph templates

### DIFF
--- a/d8_theme_main.libraries.yml
+++ b/d8_theme_main.libraries.yml
@@ -32,3 +32,7 @@ fonts:
 sprite:
   js:
     components/js/svgxuse.min.js: { attributes: { defer: true } }
+
+accordion:
+  js:
+    dist/02-molecules/accordion/accordion.js: {}

--- a/templates/paragraphs/txex_paragraph_42/paragraph--txex-paragraph-42.html.twig
+++ b/templates/paragraphs/txex_paragraph_42/paragraph--txex-paragraph-42.html.twig
@@ -1,0 +1,10 @@
+{% extends "paragraph.html.twig" %}
+
+{% set accordion_base_class = accordion_base_class|default('accordion') %}
+
+{% block paragraph %}
+{{ attach_library('d8_theme_main/accordion') }}
+  <div {{ bem(accordion_base_class, (accordion_modifiers), accordion_blockname) }}>
+    {{ content }}
+  </div>
+{% endblock paragraph %}

--- a/templates/paragraphs/txex_paragraph_43/paragraph--txex-paragraph-43.html.twig
+++ b/templates/paragraphs/txex_paragraph_43/paragraph--txex-paragraph-43.html.twig
@@ -1,0 +1,19 @@
+{% extends "paragraph.html.twig" %}
+
+{% set accordion_base_class = accordion_base_class|default('accordion') %}
+
+{% block paragraph %}
+  <div {{ bem("item", accordion_item_modifiers, accordion_base_class) }}>
+    {% include "@atoms/04-images/icons/_icon.twig" with {
+      icon_base_class: 'expand-icon',
+      icon_blockname: accordion_base_class,
+      icon_name: 'chevron',
+    } %}
+    <div {{ bem('heading', accordion_term_modifiers, accordion_base_class) }}>
+      {{ content.field_txex_ref_rev_para_01 }}
+    </div>
+    <div {{ bem('content', accordion_def_modifiers, accordion_base_class) }}>
+      {{ content.field_txex_ref_rev_para_02 }}
+    </div>
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Reference: https://app.asana.com/0/706831088057313/731594016019889

**This PR does the following:**
- adds Drupal paragraph templates and library for the accordion component

### To Review:
- [ ] `cd web/themes/custom/d8-theme-main`
- [ ] `npm start`
- [ ] Navigate to the [Pattern](http://localhost:3000/pattern-lab/public/)
- [ ] Navigate to the [Drupal page](http://texasexesd8.lndo.site/)
