### PR TITLE
Fix to URL compare to support internal links

### DIFF
--- a/templates/nodes/event/fields/field--node--field-txex-link-01--event.html.twig
+++ b/templates/nodes/event/fields/field--node--field-txex-link-01--event.html.twig
@@ -8,7 +8,7 @@
 
 {% block item_block %}
 {# only compare the first 50 characters of the strings because the title has a limit of 80 chars #}
-{% if (item.content['#title']|slice(1, 50) == item.content['#url'].getUri()|slice(1, 50)) %}
+{% if (item.content['#title']|slice(1, 50) == item.content['#url'].toString()|slice(1, 50)) %}
   {% set link_content = 'Register' %}
   {% else %}
     {% set link_content = item.content['#title'] %}


### PR DESCRIPTION
The existing link template for events compares the label with the URI to see if they match to replace with generic text.  When used with internal link with active routes this triggers an error:

> The website encountered an unexpected error. Please try again later.</br></br><em class="placeholder">UnexpectedValueException</em>: This URL has a Drupal route, so the canonical form is not a URI.

The switched the template to compare the string instead of URI and should be equivalent in normal conditions. New events get links from Salesforce and from people picking the default link will get a default text if none is provided. If the link title is required this condition should eventually no longer be needed in the template.